### PR TITLE
feat: add game stats aggregation

### DIFF
--- a/game_stats.html
+++ b/game_stats.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <link rel="apple-touch-icon" href="/logo192.png" />
+    <link rel="manifest" href="/manifest.json" />
+    <title>Bang! salvoserver - Game stats</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <script type="module" src="/src/game_stats.tsx"></script>
+  </body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,7 @@ export default function App() {
         return <GameScene
           connection={connection}
           lobbyState={scene.lobbyState}
+          gameId={scene.gameId}
           gameOptions={scene.gameOptions}
           gameChannel={gameChannel}
           overlayRef={overlayRef}

--- a/src/Locale/Czech/Labels.ts
+++ b/src/Locale/Czech/Labels.ts
@@ -185,10 +185,12 @@ export const LABELS: LabelRegistry = {
         GET_OPTIONS_DESCRIPTION: cmd => `${cmd} : zobrazí možnosti hry`,
         SET_OPTION_DESCRIPTION: cmd => `${cmd} name value : nastaví možnost hry`,
         RESET_OPTIONS_DESCRIPTION: cmd => `${cmd} : resetuje možnosti hry`,
+        GAME_ID_DESCRIPTION: cmd => `${cmd} : print game id`,
         GIVE_CARD_DESCRIPTION: cmd => `${cmd} card_name : vezme si kartu`,
         GET_RNG_SEED_DESCRIPTION: cmd => `${cmd} : zobrazí seed hry`,
         QUIT_DESCRIPTION: cmd => `${cmd} : odpojí se ze serveru`,
         
+        GAME_ID: id => `Game id: ${id}`,
         GAME_SEED: seed => `Seed hry je ${seed}`,
         
         USER_JOINED_LOBBY: username => `${username} vstoupil do lobby`,

--- a/src/Locale/Czech/Labels.ts
+++ b/src/Locale/Czech/Labels.ts
@@ -113,6 +113,17 @@ export const LABELS: LabelRegistry = {
         COLUMN_DUELS_LOST: "Prohrané souboje",
         COLUMN_KILLS: "Zabití",
         BUTTON_DOWNLOAD_CSV: "Stáhnout CSV",
+        EXTENDED_TITLE: "Rozšířené statistiky",
+        COLUMN_ELIMINATION_ORDER: "Pořadí vyřazení",
+        COLUMN_DIED_ROUND: "Zemřel v kole",
+        COLUMN_CARDS_DRAWN: "Tažené karty",
+        COLUMN_DAMAGE_DEALT: "Způsobené poškození",
+        COLUMN_HP_RECOVERED: "Vyléčeno HP",
+        COLUMN_DRAW_CHECKS_TOTAL: "Doběry (kontrola)",
+        COLUMN_DRAW_CHECKS_LUCKY: "Šťastné doběry",
+        COLUMN_DRAW_LUCK: "Štěstí",
+        COLUMN_BONUS_DRAWS: "Bonusové doběry",
+        COLUMN_EXTRA_BANGS: "Bangy navíc",
     },
 
     ui: {

--- a/src/Locale/Czech/Labels.ts
+++ b/src/Locale/Czech/Labels.ts
@@ -105,6 +105,7 @@ export const LABELS: LabelRegistry = {
         COLUMN_CHARACTER: "Postava",
         COLUMN_ROLE: "Role",
         COLUMN_SURVIVED: "Přežil",
+        COLUMN_WON: "Vyhrál",
         COLUMN_BANGS_PLAYED: "Zahrané Bangy",
         COLUMN_ABILITY_USES: "Použití schopnosti",
         COLUMN_DYNAMITE_EXPLOSIONS: "Výbuchy dynamitu",

--- a/src/Locale/Czech/Labels.ts
+++ b/src/Locale/Czech/Labels.ts
@@ -96,6 +96,24 @@ export const LABELS: LabelRegistry = {
         'icon-renegade':        "Odpadlík",
     },
 
+    GameStats: {
+        TITLE: "Statistiky hry",
+        LOADING: "Načítám statistiky...",
+        NOT_FOUND: "Statistiky hry nenalezeny.",
+        NUM_ROUNDS: "Počet kol",
+        COLUMN_PLAYER: "Hráč",
+        COLUMN_CHARACTER: "Postava",
+        COLUMN_ROLE: "Role",
+        COLUMN_SURVIVED: "Přežil",
+        COLUMN_BANGS_PLAYED: "Zahrané Bangy",
+        COLUMN_ABILITY_USES: "Použití schopnosti",
+        COLUMN_DYNAMITE_EXPLOSIONS: "Výbuchy dynamitu",
+        COLUMN_PRISON_TURNS: "Tahy ve vězení",
+        COLUMN_DUELS_LOST: "Prohrané souboje",
+        COLUMN_KILLS: "Zabití",
+        BUTTON_DOWNLOAD_CSV: "Stáhnout CSV",
+    },
+
     ui: {
         APP_TITLE: "Bang!",
         APP_WELCOME: "Vítej na bang.salvoserver.it,\nBang! online se všemi rozšířeními!\nHraj hned zdarma s kamarády!",
@@ -123,6 +141,7 @@ export const LABELS: LabelRegistry = {
         BUTTON_ENABLE_SOUNDS: "Zapnout zvuky",
         BUTTON_DISABLE_SOUNDS: "Vypnout zvuky",
         BUTTON_RETURN_LOBBY: "Zpět do lobby",
+        BUTTON_VIEW_STATS: "Zobrazit statistiky",
         BUTTON_OK: "OK",
         BUTTON_UNDO: "Zpět",
         BUTTON_YES: "Ano",

--- a/src/Locale/English/Labels.ts
+++ b/src/Locale/English/Labels.ts
@@ -105,6 +105,7 @@ export const LABELS: LabelRegistry = {
         COLUMN_CHARACTER: "Character",
         COLUMN_ROLE: "Role",
         COLUMN_SURVIVED: "Survived",
+        COLUMN_WON: "Won",
         COLUMN_BANGS_PLAYED: "Bangs Played",
         COLUMN_ABILITY_USES: "Ability Uses",
         COLUMN_DYNAMITE_EXPLOSIONS: "Dynamite Explosions",

--- a/src/Locale/English/Labels.ts
+++ b/src/Locale/English/Labels.ts
@@ -185,10 +185,12 @@ export const LABELS: LabelRegistry = {
         GET_OPTIONS_DESCRIPTION: cmd => `${cmd} : print game options`,
         SET_OPTION_DESCRIPTION: cmd => `${cmd} name value : set a game option`,
         RESET_OPTIONS_DESCRIPTION: cmd => `${cmd} : reset game options`,
+        GAME_ID_DESCRIPTION: cmd => `${cmd} : print game id`,
         GIVE_CARD_DESCRIPTION: cmd => `${cmd} card_name : give yourself a card`,
         GET_RNG_SEED_DESCRIPTION: cmd => `${cmd} : print rng seed`,
         QUIT_DESCRIPTION: cmd => `${cmd} : disconnect from server`,
         
+        GAME_ID: id => `Game id: ${id}`,
         GAME_SEED: seed => `The game seed is ${seed}`,
         
         USER_JOINED_LOBBY: username => `${username} joined the lobby`,

--- a/src/Locale/English/Labels.ts
+++ b/src/Locale/English/Labels.ts
@@ -113,6 +113,17 @@ export const LABELS: LabelRegistry = {
         COLUMN_DUELS_LOST: "Duels Lost",
         COLUMN_KILLS: "Kills",
         BUTTON_DOWNLOAD_CSV: "Download CSV",
+        EXTENDED_TITLE: "Extended Stats",
+        COLUMN_ELIMINATION_ORDER: "Elimination Order",
+        COLUMN_DIED_ROUND: "Died on Round",
+        COLUMN_CARDS_DRAWN: "Cards Drawn",
+        COLUMN_DAMAGE_DEALT: "Damage Dealt",
+        COLUMN_HP_RECOVERED: "HP Recovered",
+        COLUMN_DRAW_CHECKS_TOTAL: "Draw Checks",
+        COLUMN_DRAW_CHECKS_LUCKY: "Lucky Draw Checks",
+        COLUMN_DRAW_LUCK: "Luck",
+        COLUMN_BONUS_DRAWS: "Bonus Draws",
+        COLUMN_EXTRA_BANGS: "Extra Bangs",
     },
 
     ui: {

--- a/src/Locale/English/Labels.ts
+++ b/src/Locale/English/Labels.ts
@@ -96,6 +96,24 @@ export const LABELS: LabelRegistry = {
         'icon-renegade':        "Renegade",
     },
 
+    GameStats: {
+        TITLE: "Game Stats",
+        LOADING: "Loading stats...",
+        NOT_FOUND: "No game stats found.",
+        NUM_ROUNDS: "Rounds",
+        COLUMN_PLAYER: "Player",
+        COLUMN_CHARACTER: "Character",
+        COLUMN_ROLE: "Role",
+        COLUMN_SURVIVED: "Survived",
+        COLUMN_BANGS_PLAYED: "Bangs Played",
+        COLUMN_ABILITY_USES: "Ability Uses",
+        COLUMN_DYNAMITE_EXPLOSIONS: "Dynamite Explosions",
+        COLUMN_PRISON_TURNS: "Prison Turns",
+        COLUMN_DUELS_LOST: "Duels Lost",
+        COLUMN_KILLS: "Kills",
+        BUTTON_DOWNLOAD_CSV: "Download CSV",
+    },
+
     ui: {
         APP_TITLE: "Bang!",
         APP_WELCOME: "Welcome to bang.salvoserver.it,\nBang! online with all expansions!\nPlay now for free with your friends!",
@@ -123,6 +141,7 @@ export const LABELS: LabelRegistry = {
         BUTTON_ENABLE_SOUNDS: "Enable Sounds",
         BUTTON_DISABLE_SOUNDS: "Disable Sounds",
         BUTTON_RETURN_LOBBY: "Return to Lobby",
+        BUTTON_VIEW_STATS: "View Stats",
         BUTTON_OK: "OK",
         BUTTON_UNDO: "Undo",
         BUTTON_YES: "Yes",

--- a/src/Locale/Hungarian/Labels.ts
+++ b/src/Locale/Hungarian/Labels.ts
@@ -165,10 +165,12 @@ export const LABELS: LabelRegistry = {
         GET_OPTIONS_DESCRIPTION: cmd => `${cmd} : játék beállításainak kiíratása`,
         SET_OPTION_DESCRIPTION: cmd => `${cmd} név érték : játékbeállítás megváltoztatása`,
         RESET_OPTIONS_DESCRIPTION: cmd => `${cmd} : játék beállítások alaphelyzetbe állítása`,
+        GAME_ID_DESCRIPTION: cmd => `${cmd} : print game id`,
         GIVE_CARD_DESCRIPTION: cmd => `${cmd} kártya_neve : kártya odaadása magadnak`,
         GET_RNG_SEED_DESCRIPTION: cmd => `${cmd} : véletlenszám-generátor seed kiíratása`,
         QUIT_DESCRIPTION: cmd => `${cmd} : lecsatlakozás a szerverről`,
         
+        GAME_ID: id => `Game id: ${id}`,
         GAME_SEED: seed => `A játék seedje ${seed}`,
         
         USER_JOINED_LOBBY: username => `${username} csatlakozott a lobbiba`,

--- a/src/Locale/Italian/Labels.ts
+++ b/src/Locale/Italian/Labels.ts
@@ -165,10 +165,12 @@ export const LABELS: LabelRegistry = {
         GET_OPTIONS_DESCRIPTION: cmd => `${cmd} : visualizza le opzioni di gioco`,
         SET_OPTION_DESCRIPTION: cmd => `${cmd} name value : modifica un'opzione di gioco`,
         RESET_OPTIONS_DESCRIPTION: cmd => `${cmd} : resetta le opzioni di gioco`,
+        GAME_ID_DESCRIPTION: cmd => `${cmd} : visualizza l'id di gioco`,
         GIVE_CARD_DESCRIPTION: cmd => `${cmd} card_name : prendi una carta`,
         GET_RNG_SEED_DESCRIPTION: cmd => `${cmd} : visualizza il seed di gioco`,
         QUIT_DESCRIPTION: cmd => `${cmd} : disconnettiti dal server`,
         
+        GAME_ID: id => `Game id: ${id}`,
         GAME_SEED: seed => `Il seed di gioco è ${seed}`,
         
         USER_JOINED_LOBBY: (username) => `${username} entra in lobby`,

--- a/src/Locale/Spanish/Labels.ts
+++ b/src/Locale/Spanish/Labels.ts
@@ -165,10 +165,12 @@ export const LABELS: LabelRegistry = {
         GET_OPTIONS_DESCRIPTION: cmd => `${cmd} : muestra las opciones del juego`,
         SET_OPTION_DESCRIPTION: cmd => `${cmd} nombre valor : establecer una opción del juego`,
         RESET_OPTIONS_DESCRIPTION: cmd => `${cmd} : reiniciar las opciones del juego`,
+        GAME_ID_DESCRIPTION: cmd => `${cmd} : print game id`,
         GIVE_CARD_DESCRIPTION: cmd => `${cmd} nombre_de_carta : darte una carta a ti mismo`,
         GET_RNG_SEED_DESCRIPTION: cmd => `${cmd} : muestra la semilla del generador aleatorio`,
         QUIT_DESCRIPTION: cmd => `${cmd} : desconectar del servidor`,
 
+        GAME_ID: id => `Game id: ${id}`,
         GAME_SEED: seed => `La semilla del juego es ${seed}`,
 
         USER_JOINED_LOBBY: username => `${username} se unió a la sala`,

--- a/src/Model/Env.ts
+++ b/src/Model/Env.ts
@@ -17,8 +17,9 @@ const Env = (() => {
     const bangTrackingUrl = bangServerBaseUrl + 'tracking';
     const bangCardsUrl = bangServerBaseUrl + 'cards';
     const bangImageUrl = bangServerBaseUrl + 'image';
+    const bangGamesUrl = bangServerBaseUrl + 'games';
 
-    return { bangServerUrl, bangTrackingUrl, bangCardsUrl, bangImageUrl, language, discordLink } as const;
+    return { bangServerUrl, bangTrackingUrl, bangCardsUrl, bangImageUrl, bangGamesUrl, language, discordLink } as const;
 })();
 
 export default Env;

--- a/src/Model/SceneState.ts
+++ b/src/Model/SceneState.ts
@@ -1,6 +1,6 @@
 import { GameOptions } from "../Scenes/Game/Model/GameUpdate";
 import { createUnionReducer, Empty } from "../Utils/UnionUtils";
-import { ChatMessage, LobbyEntered, LobbyId, LobbyUserFlag, LobbyValue, UserId, UserValue } from "./ServerMessage";
+import { ChatMessage, GameId, GameStarted, LobbyEntered, LobbyId, LobbyUserFlag, LobbyValue, UserId, UserValue } from "./ServerMessage";
 
 export interface LobbyState {
     lobbyId: LobbyId;
@@ -30,7 +30,8 @@ export type SceneState = { error?: ErrorState } & (
     { type: 'home' } |
     { type: 'loading', message: string } |
     { type: 'waiting_area', lobbies: LobbyValue[] } |
-    { type: 'lobby' | 'game', lobbyName: string, gameOptions: GameOptions, lobbyState: LobbyState }
+    { type: 'lobby', lobbyName: string, gameOptions: GameOptions, lobbyState: LobbyState } |
+    { type: 'game', lobbyName: string, gameOptions: GameOptions, lobbyState: LobbyState, gameId: GameId }
 );
 
 export type SceneUpdate =
@@ -38,7 +39,7 @@ export type SceneUpdate =
     { gotoLoading: string } |
     { gotoWaitingArea: Empty } |
     { gotoLobby: LobbyEntered } |
-    { gotoGame: Empty } |
+    { gotoGame: GameStarted } |
     { setError: ErrorState | null } |
     { updateLobbies: LobbyValue } |
     { removeLobby: LobbyId } |
@@ -85,11 +86,11 @@ export const sceneReducer = createUnionReducer<SceneState, SceneUpdate>({
                 : newLobbyState(lobby_id, user_id)
         };
     },
-    gotoGame() {
+    gotoGame({ game_id }) {
         if (this.type !== 'lobby') {
             throw new Error('Invalid scene type for gotoGame: ' + this.type);
         }
-        return { ...this, type: 'game' };
+        return { ...this, type: 'game', gameId: game_id };
     },
     setError(error) {
         return { ...this, error: error ?? undefined };

--- a/src/Model/ServerMessage.ts
+++ b/src/Model/ServerMessage.ts
@@ -3,6 +3,7 @@ import { Container, ContainerKey, parseContainer } from "../Utils/ArrayUtils";
 import { Empty } from "../Utils/UnionUtils";
 
 export type LobbyId = number;
+export type GameId = number;
 export type UserId = number;
 export type Milliseconds = number;
 
@@ -73,6 +74,10 @@ export function parseChatMessage(message: ChatMessageArgs): ChatMessage {
     return { ...message, flags: parseContainer(message.flags) };
 }
 
+export interface GameStarted {
+    game_id: GameId;
+}
+
 export type ServerMessage =
     {ping: Empty} |
     {client_accepted: ClientAccepted} |
@@ -85,4 +90,4 @@ export type ServerMessage =
     {lobby_kick: Empty} |
     {lobby_chat: ChatMessageArgs} |
     {game_update: GameUpdate} |
-    {game_started: Empty};
+    {game_started: GameStarted};

--- a/src/Model/UseBangConnection.ts
+++ b/src/Model/UseBangConnection.ts
@@ -103,8 +103,8 @@ export default function useBangConnection() {
         game_update(update) {
             gameChannel.update(update);
         },
-        game_started() {
-            sceneDispatch({ gotoGame: {} });
+        game_started({ game_id }) {
+            sceneDispatch({ gotoGame: { game_id } });
         },
     })), [connection, settings, gameChannel]);
 

--- a/src/Scenes/Game/GameScene.tsx
+++ b/src/Scenes/Game/GameScene.tsx
@@ -2,7 +2,7 @@ import { RefObject, createContext, useState } from "react";
 import { createPortal } from "react-dom";
 import useEvent from "react-use-event-hook";
 import { LobbyState } from "../../Model/SceneState";
-import { UserId } from "../../Model/ServerMessage";
+import { GameId, UserId } from "../../Model/ServerMessage";
 import { BangConnection, GameChannel } from "../../Model/UseBangConnection";
 import { isMobileDevice } from "../../Utils/MobileCheck";
 import { useMapRef } from "../../Utils/UseMapRef";
@@ -37,17 +37,18 @@ import FeatsPocket from "./Pockets/FeatsPocket";
 export interface GameProps {
   connection: BangConnection;
   lobbyState: LobbyState;
+  gameId: GameId;
   gameOptions: GameOptions;
   gameChannel: GameChannel;
   overlayRef: RefObject<HTMLDivElement>;
   muteSounds?: boolean;
 }
 
-const EMPTY_GAME_STATE = newGameState(0);
+const EMPTY_GAME_STATE = newGameState({ gameId: 0, myUserId: 0 });
 export const GameStateContext = createContext(EMPTY_GAME_STATE);
 
-export default function GameScene({ connection, lobbyState, gameOptions, gameChannel, overlayRef, muteSounds }: GameProps) {
-  const { loaded, state, selectorDispatch, gameLogs, gameError, clearGameError } = useGameState(gameChannel, lobbyState.myUserId, muteSounds ?? false);
+export default function GameScene({ connection, lobbyState, gameId, gameOptions, gameChannel, overlayRef, muteSounds }: GameProps) {
+  const { loaded, state, selectorDispatch, gameLogs, gameError, clearGameError } = useGameState(gameChannel, gameId, lobbyState.myUserId, muteSounds ?? false);
   const { table, selector } = state;
 
   const pocketRefs = useMapRef<PocketType, PocketRef>();

--- a/src/Scenes/Game/Model/UseGameState.ts
+++ b/src/Scenes/Game/Model/UseGameState.ts
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useReducer, useRef, useState } from "react";
-import { Milliseconds, UserId } from "../../../Model/ServerMessage";
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
+import { GameId, Milliseconds, UserId } from "../../../Model/ServerMessage";
 import { GameChannel } from "../../../Model/UseBangConnection";
 import { createUnionDispatch, createUnionReducer } from "../../../Utils/UnionUtils";
 import { preloadAssets, usePlaySound } from "../../../Utils/UseAssets";
@@ -10,6 +10,7 @@ import { newTargetSelector, TargetSelector } from "./TargetSelector";
 import targetSelectorReducer, { SelectorUpdate } from "./TargetSelectorReducer";
 
 export interface GameState {
+    gameId: GameId;
     table: GameTable;
     selector: TargetSelector;
 }
@@ -27,16 +28,18 @@ const gameStateReducer = createUnionReducer<GameState, GameStateUpdate>({
     }
 });
 
-export function newGameState(myUserId: UserId): GameState {
+export function newGameState({ gameId, myUserId}: { gameId: GameId, myUserId: UserId }): GameState {
     return {
+        gameId,
         table: newGameTable(myUserId),
         selector: newTargetSelector()
     };
 }
 
-export default function useGameState(gameChannel: GameChannel, myUserId: UserId, muteSounds: boolean) {
+export default function useGameState(gameChannel: GameChannel, gameId: GameId, myUserId: UserId, muteSounds: boolean) {
     const [loaded, setLoaded] = useState(false);
-    const [state, stateDispatch] = useReducer(gameStateReducer, myUserId, newGameState);
+    const initArg = useMemo(() => ({ gameId, myUserId }), [gameId, myUserId]);
+    const [state, stateDispatch] = useReducer(gameStateReducer, initArg, newGameState);
 
     const [gameLogs, setGameLogs] = useState<GameString[]>([]);
     const [gameError, setGameError] = useState<GameString>();

--- a/src/Scenes/Game/StatusBar.tsx
+++ b/src/Scenes/Game/StatusBar.tsx
@@ -59,8 +59,10 @@ export default function StatusBar({ gameError, handleClearGameError, handleRetur
   const undoButton = handleUndo && <Button color='red' onClick={handleUndo}>{getLabel(language, 'ui', 'BUTTON_UNDO')}</Button>;
 
   if (isGameOver) {
+    const handleViewStats = () => window.open(`game_stats.html?lobby=${lobbyState.lobbyId}`, '_blank');
     return <div className="status-bar">
       {getLabel(language, 'ui', 'STATUS_GAME_OVER')}
+      <Button color='blue' onClick={handleViewStats}>{getLabel(language, 'ui', 'BUTTON_VIEW_STATS')}</Button>
       {checkMyUserFlag(lobbyState, 'lobby_owner') && <Button color='green' onClick={handleReturnLobby}>{getLabel(language, 'ui', 'BUTTON_RETURN_LOBBY')}</Button>}
     </div>
   } else if (gameError) {

--- a/src/Scenes/Game/StatusBar.tsx
+++ b/src/Scenes/Game/StatusBar.tsx
@@ -32,7 +32,7 @@ function getCardButtonColor(card: Card): ButtonColor {
 
 export default function StatusBar({ gameError, handleClearGameError, handleReturnLobby }: StatusProps) {
   const lobbyState = useContext(LobbyContext);
-  const { table, selector } = useContext(GameStateContext);
+  const { gameId, table, selector } = useContext(GameStateContext);
   const { handleClickCard, handleConfirm, handleUndo } = useSelectorConfirm();
   const language = useLanguage();
 
@@ -59,7 +59,7 @@ export default function StatusBar({ gameError, handleClearGameError, handleRetur
   const undoButton = handleUndo && <Button color='red' onClick={handleUndo}>{getLabel(language, 'ui', 'BUTTON_UNDO')}</Button>;
 
   if (isGameOver) {
-    const handleViewStats = () => window.open(`game_stats.html?lobby=${lobbyState.lobbyId}`, '_blank');
+    const handleViewStats = () => window.open(`game_stats.html?game=${gameId}`, '_blank');
     return <div className="status-bar">
       {getLabel(language, 'ui', 'STATUS_GAME_OVER')}
       <Button color='blue' onClick={handleViewStats}>{getLabel(language, 'ui', 'BUTTON_VIEW_STATS')}</Button>

--- a/src/Scenes/GameStats/GameStats.tsx
+++ b/src/Scenes/GameStats/GameStats.tsx
@@ -1,6 +1,7 @@
 import "../../App.css";
 import BangLogo from "../../Components/BangLogo";
 import Button from "../../Components/Button";
+import Collapsible from "../../Components/Collapsible";
 import { getLabel, Language, LanguageProvider, useLanguage } from "../../Locale/Registry";
 import Env from "../../Model/Env";
 import { downloadCsv } from "../../Utils/FileUtils";
@@ -15,6 +16,13 @@ interface PlayerStats {
     prison_turns_skipped: number;
     duels_lost: number;
     kills: number;
+    cards_drawn: number;
+    damage_dealt: number;
+    hp_recovered: number;
+    draw_checks_total: number;
+    draw_checks_lucky: number;
+    bonus_draws_used: number;
+    volcanic_bangs_played: number;
 }
 
 interface PlayerGameReport {
@@ -25,6 +33,8 @@ interface PlayerGameReport {
     role: string;
     survived: boolean;
     won: boolean;
+    elimination_order: number;
+    died_on_round: number;
     stats: PlayerStats;
 }
 
@@ -56,6 +66,14 @@ function sortPlayers(players: PlayerGameReport[]): PlayerGameReport[] {
     });
 }
 
+function formatLuck(total: number, lucky: number): string {
+    return total === 0 ? '-' : `${lucky}/${total} (${Math.round(lucky / total * 100)}%)`;
+}
+
+function formatOrNone(value: number): string {
+    return value === 0 ? '-' : value.toString();
+}
+
 function GameStatsTable({ game }: { game: GameReport }) {
     const language = useLanguage();
     const players = sortPlayers(game.players);
@@ -75,6 +93,15 @@ function GameStatsTable({ game }: { game: GameReport }) {
             getLabel(language, 'GameStats', 'COLUMN_PRISON_TURNS'),
             getLabel(language, 'GameStats', 'COLUMN_DUELS_LOST'),
             getLabel(language, 'GameStats', 'COLUMN_KILLS'),
+            getLabel(language, 'GameStats', 'COLUMN_ELIMINATION_ORDER'),
+            getLabel(language, 'GameStats', 'COLUMN_DIED_ROUND'),
+            getLabel(language, 'GameStats', 'COLUMN_CARDS_DRAWN'),
+            getLabel(language, 'GameStats', 'COLUMN_DAMAGE_DEALT'),
+            getLabel(language, 'GameStats', 'COLUMN_HP_RECOVERED'),
+            getLabel(language, 'GameStats', 'COLUMN_DRAW_CHECKS_TOTAL'),
+            getLabel(language, 'GameStats', 'COLUMN_DRAW_CHECKS_LUCKY'),
+            getLabel(language, 'GameStats', 'COLUMN_BONUS_DRAWS'),
+            getLabel(language, 'GameStats', 'COLUMN_EXTRA_BANGS'),
         ];
         const rows = players.map(player => [
             player.username,
@@ -88,6 +115,15 @@ function GameStatsTable({ game }: { game: GameReport }) {
             player.stats.prison_turns_skipped.toString(),
             player.stats.duels_lost.toString(),
             player.stats.kills.toString(),
+            player.elimination_order.toString(),
+            player.died_on_round.toString(),
+            player.stats.cards_drawn.toString(),
+            player.stats.damage_dealt.toString(),
+            player.stats.hp_recovered.toString(),
+            player.stats.draw_checks_total.toString(),
+            player.stats.draw_checks_lucky.toString(),
+            player.stats.bonus_draws_used.toString(),
+            player.stats.volcanic_bangs_played.toString(),
         ]);
         downloadCsv(`bang_game_${game.game_id}.csv`, [header, ...rows]);
     };
@@ -131,6 +167,40 @@ function GameStatsTable({ game }: { game: GameReport }) {
                 </tbody>
             </table>
         </div>
+        <Collapsible label={getLabel(language, 'GameStats', 'EXTENDED_TITLE')} storageKey="game-stats-extended" defaultExpanded={false}>
+            <div className="overflow-x-auto w-full">
+                <table className="game-stats-table min-w-full border-collapse text-center">
+                    <thead>
+                        <tr>
+                            <th>{getLabel(language, 'GameStats', 'COLUMN_PLAYER')}</th>
+                            <th>{getLabel(language, 'GameStats', 'COLUMN_ELIMINATION_ORDER')}</th>
+                            <th>{getLabel(language, 'GameStats', 'COLUMN_DIED_ROUND')}</th>
+                            <th>{getLabel(language, 'GameStats', 'COLUMN_CARDS_DRAWN')}</th>
+                            <th>{getLabel(language, 'GameStats', 'COLUMN_DAMAGE_DEALT')}</th>
+                            <th>{getLabel(language, 'GameStats', 'COLUMN_HP_RECOVERED')}</th>
+                            <th>{getLabel(language, 'GameStats', 'COLUMN_DRAW_LUCK')}</th>
+                            <th>{getLabel(language, 'GameStats', 'COLUMN_BONUS_DRAWS')}</th>
+                            <th>{getLabel(language, 'GameStats', 'COLUMN_EXTRA_BANGS')}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {players.map(player => (
+                            <tr key={player.user_id} className={player.won ? 'game-stats-winner' : ''}>
+                                <td className="font-medium">{player.username}</td>
+                                <td>{formatOrNone(player.elimination_order)}</td>
+                                <td>{formatOrNone(player.died_on_round)}</td>
+                                <td>{player.stats.cards_drawn}</td>
+                                <td>{player.stats.damage_dealt}</td>
+                                <td>{player.stats.hp_recovered}</td>
+                                <td>{formatLuck(player.stats.draw_checks_total, player.stats.draw_checks_lucky)}</td>
+                                <td>{player.stats.bonus_draws_used}</td>
+                                <td>{player.stats.volcanic_bangs_played}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        </Collapsible>
         <div className="flex justify-center mt-4">
             <Button color='blue' onClick={handleDownloadCsv}>{getLabel(language, 'GameStats', 'BUTTON_DOWNLOAD_CSV')}</Button>
         </div>

--- a/src/Scenes/GameStats/GameStats.tsx
+++ b/src/Scenes/GameStats/GameStats.tsx
@@ -1,3 +1,4 @@
+import "../../App.css";
 import BangLogo from "../../Components/BangLogo";
 import Button from "../../Components/Button";
 import { getLabel, Language, LanguageProvider, useLanguage } from "../../Locale/Registry";
@@ -5,7 +6,6 @@ import Env from "../../Model/Env";
 import { downloadCsv } from "../../Utils/FileUtils";
 import useFetch from "../../Utils/UseFetch";
 import { getLocalizedCardName } from "../Game/GameStringComponent";
-import "../../App.css";
 import "./Style/GameStats.css";
 
 interface PlayerStats {
@@ -29,7 +29,7 @@ interface PlayerGameReport {
 }
 
 interface GameReport {
-    game_id: string;
+    game_id: number;
     lobby_id: number;
     started_at: number;
     ended_at: number;
@@ -137,29 +137,27 @@ function GameStatsTable({ game }: { game: GameReport }) {
     </>;
 }
 
-function GameStatsInner() {
+function GameStatsInner({ gameId }: { gameId: string }) {
     const language = useLanguage();
-    const params = new URLSearchParams(window.location.search);
-    const lobbyId = params.get('lobby') ?? '';
 
-    const gamesUrl = Env.bangGamesUrl + '?' + new URLSearchParams({ lobby: lobbyId, limit: '1' }).toString();
-    const games = useFetch<GameReport[]>(gamesUrl);
+    const gamesUrl = Env.bangGamesUrl + '/' + gameId;
+    const report = useFetch<GameReport>(gamesUrl);
 
-    if (!games) {
+    if (!report) {
         return <div className="game-stats-subtitle">{getLabel(language, 'GameStats', 'LOADING')}</div>;
     }
-    if (games.length === 0) {
-        return <div className="game-stats-subtitle">{getLabel(language, 'GameStats', 'NOT_FOUND')}</div>;
-    }
-    return <GameStatsTable game={games[0]} />;
+    return <GameStatsTable game={report} />;
 }
 
 export default function GameStatsScene() {
-    return <LanguageProvider>
+    const params = new URLSearchParams(window.location.search);
+    const gameId = params.get('game');
+
+    return gameId && <LanguageProvider>
         <div className="game-stats-scene">
             <BangLogo />
             <div className="game-stats-panel">
-                <GameStatsInner />
+                <GameStatsInner gameId={gameId} />
             </div>
         </div>
     </LanguageProvider>;

--- a/src/Scenes/GameStats/GameStats.tsx
+++ b/src/Scenes/GameStats/GameStats.tsx
@@ -1,9 +1,12 @@
+import BangLogo from "../../Components/BangLogo";
 import Button from "../../Components/Button";
 import { getLabel, Language, LanguageProvider, useLanguage } from "../../Locale/Registry";
 import Env from "../../Model/Env";
 import { downloadCsv } from "../../Utils/FileUtils";
 import useFetch from "../../Utils/UseFetch";
 import { getLocalizedCardName } from "../Game/GameStringComponent";
+import "../../App.css";
+import "./Style/GameStats.css";
 
 interface PlayerStats {
     bangs_played: number;
@@ -21,6 +24,7 @@ interface PlayerGameReport {
     character: string;
     role: string;
     survived: boolean;
+    won: boolean;
     stats: PlayerStats;
 }
 
@@ -46,6 +50,7 @@ function getLocalizedRole(language: Language, role: string): string {
 
 function sortPlayers(players: PlayerGameReport[]): PlayerGameReport[] {
     return [...players].sort((a, b) => {
+        if (a.won !== b.won) return a.won ? -1 : 1;
         if (a.survived !== b.survived) return a.survived ? -1 : 1;
         return b.stats.kills - a.stats.kills;
     });
@@ -63,6 +68,7 @@ function GameStatsTable({ game }: { game: GameReport }) {
             getLabel(language, 'GameStats', 'COLUMN_CHARACTER'),
             getLabel(language, 'GameStats', 'COLUMN_ROLE'),
             getLabel(language, 'GameStats', 'COLUMN_SURVIVED'),
+            getLabel(language, 'GameStats', 'COLUMN_WON'),
             getLabel(language, 'GameStats', 'COLUMN_BANGS_PLAYED'),
             getLabel(language, 'GameStats', 'COLUMN_ABILITY_USES'),
             getLabel(language, 'GameStats', 'COLUMN_DYNAMITE_EXPLOSIONS'),
@@ -75,6 +81,7 @@ function GameStatsTable({ game }: { game: GameReport }) {
             getLocalizedCardName(language, player.character),
             getLocalizedRole(language, player.role),
             yesNo(player.survived),
+            yesNo(player.won),
             player.stats.bangs_played.toString(),
             player.stats.ability_uses.toString(),
             player.stats.dynamite_explosions.toString(),
@@ -85,45 +92,49 @@ function GameStatsTable({ game }: { game: GameReport }) {
         downloadCsv(`bang_game_${game.game_id}.csv`, [header, ...rows]);
     };
 
-    return <div className="flex flex-col items-center gap-4 p-4">
-        <h1 className="text-2xl font-bold">{getLabel(language, 'GameStats', 'TITLE')}</h1>
-        <div className="text-gray-600">{getLabel(language, 'GameStats', 'NUM_ROUNDS')}: {game.num_rounds}</div>
+    return <>
+        <h1 className="game-stats-title">{getLabel(language, 'GameStats', 'TITLE')}</h1>
+        <div className="game-stats-subtitle">{getLabel(language, 'GameStats', 'NUM_ROUNDS')}: {game.num_rounds}</div>
         <div className="overflow-x-auto w-full">
-            <table className="min-w-full border-collapse text-center">
+            <table className="game-stats-table min-w-full border-collapse text-center">
                 <thead>
-                    <tr className="border-b border-gray-400">
-                        <th className="p-2">{getLabel(language, 'GameStats', 'COLUMN_PLAYER')}</th>
-                        <th className="p-2">{getLabel(language, 'GameStats', 'COLUMN_CHARACTER')}</th>
-                        <th className="p-2">{getLabel(language, 'GameStats', 'COLUMN_ROLE')}</th>
-                        <th className="p-2">{getLabel(language, 'GameStats', 'COLUMN_SURVIVED')}</th>
-                        <th className="p-2">{getLabel(language, 'GameStats', 'COLUMN_BANGS_PLAYED')}</th>
-                        <th className="p-2">{getLabel(language, 'GameStats', 'COLUMN_ABILITY_USES')}</th>
-                        <th className="p-2">{getLabel(language, 'GameStats', 'COLUMN_DYNAMITE_EXPLOSIONS')}</th>
-                        <th className="p-2">{getLabel(language, 'GameStats', 'COLUMN_PRISON_TURNS')}</th>
-                        <th className="p-2">{getLabel(language, 'GameStats', 'COLUMN_DUELS_LOST')}</th>
-                        <th className="p-2">{getLabel(language, 'GameStats', 'COLUMN_KILLS')}</th>
+                    <tr>
+                        <th>{getLabel(language, 'GameStats', 'COLUMN_PLAYER')}</th>
+                        <th>{getLabel(language, 'GameStats', 'COLUMN_CHARACTER')}</th>
+                        <th>{getLabel(language, 'GameStats', 'COLUMN_ROLE')}</th>
+                        <th>{getLabel(language, 'GameStats', 'COLUMN_SURVIVED')}</th>
+                        <th>{getLabel(language, 'GameStats', 'COLUMN_WON')}</th>
+                        <th>{getLabel(language, 'GameStats', 'COLUMN_BANGS_PLAYED')}</th>
+                        <th>{getLabel(language, 'GameStats', 'COLUMN_ABILITY_USES')}</th>
+                        <th>{getLabel(language, 'GameStats', 'COLUMN_DYNAMITE_EXPLOSIONS')}</th>
+                        <th>{getLabel(language, 'GameStats', 'COLUMN_PRISON_TURNS')}</th>
+                        <th>{getLabel(language, 'GameStats', 'COLUMN_DUELS_LOST')}</th>
+                        <th>{getLabel(language, 'GameStats', 'COLUMN_KILLS')}</th>
                     </tr>
                 </thead>
                 <tbody>
                     {players.map(player => (
-                        <tr key={player.user_id} className="border-b border-gray-200">
-                            <td className="p-2 font-medium">{player.username}</td>
-                            <td className="p-2">{getLocalizedCardName(language, player.character)}</td>
-                            <td className="p-2">{getLocalizedRole(language, player.role)}</td>
-                            <td className="p-2">{yesNo(player.survived)}</td>
-                            <td className="p-2">{player.stats.bangs_played}</td>
-                            <td className="p-2">{player.stats.ability_uses}</td>
-                            <td className="p-2">{player.stats.dynamite_explosions}</td>
-                            <td className="p-2">{player.stats.prison_turns_skipped}</td>
-                            <td className="p-2">{player.stats.duels_lost}</td>
-                            <td className="p-2">{player.stats.kills}</td>
+                        <tr key={player.user_id} className={player.won ? 'game-stats-winner' : ''}>
+                            <td className="font-medium">{player.username}</td>
+                            <td>{getLocalizedCardName(language, player.character)}</td>
+                            <td>{getLocalizedRole(language, player.role)}</td>
+                            <td>{yesNo(player.survived)}</td>
+                            <td>{yesNo(player.won)}</td>
+                            <td>{player.stats.bangs_played}</td>
+                            <td>{player.stats.ability_uses}</td>
+                            <td>{player.stats.dynamite_explosions}</td>
+                            <td>{player.stats.prison_turns_skipped}</td>
+                            <td>{player.stats.duels_lost}</td>
+                            <td>{player.stats.kills}</td>
                         </tr>
                     ))}
                 </tbody>
             </table>
         </div>
-        <Button color='blue' onClick={handleDownloadCsv}>{getLabel(language, 'GameStats', 'BUTTON_DOWNLOAD_CSV')}</Button>
-    </div>;
+        <div className="flex justify-center mt-4">
+            <Button color='blue' onClick={handleDownloadCsv}>{getLabel(language, 'GameStats', 'BUTTON_DOWNLOAD_CSV')}</Button>
+        </div>
+    </>;
 }
 
 function GameStatsInner() {
@@ -135,16 +146,21 @@ function GameStatsInner() {
     const games = useFetch<GameReport[]>(gamesUrl);
 
     if (!games) {
-        return <div className="p-4 text-center">{getLabel(language, 'GameStats', 'LOADING')}</div>;
+        return <div className="game-stats-subtitle">{getLabel(language, 'GameStats', 'LOADING')}</div>;
     }
     if (games.length === 0) {
-        return <div className="p-4 text-center">{getLabel(language, 'GameStats', 'NOT_FOUND')}</div>;
+        return <div className="game-stats-subtitle">{getLabel(language, 'GameStats', 'NOT_FOUND')}</div>;
     }
     return <GameStatsTable game={games[0]} />;
 }
 
 export default function GameStatsScene() {
     return <LanguageProvider>
-        <GameStatsInner />
+        <div className="game-stats-scene">
+            <BangLogo />
+            <div className="game-stats-panel">
+                <GameStatsInner />
+            </div>
+        </div>
     </LanguageProvider>;
 }

--- a/src/Scenes/GameStats/GameStats.tsx
+++ b/src/Scenes/GameStats/GameStats.tsx
@@ -1,0 +1,150 @@
+import Button from "../../Components/Button";
+import { getLabel, Language, LanguageProvider, useLanguage } from "../../Locale/Registry";
+import Env from "../../Model/Env";
+import { downloadCsv } from "../../Utils/FileUtils";
+import useFetch from "../../Utils/UseFetch";
+import { getLocalizedCardName } from "../Game/GameStringComponent";
+
+interface PlayerStats {
+    bangs_played: number;
+    ability_uses: number;
+    dynamite_explosions: number;
+    prison_turns_skipped: number;
+    duels_lost: number;
+    kills: number;
+}
+
+interface PlayerGameReport {
+    user_id: number;
+    username: string;
+    is_bot: boolean;
+    character: string;
+    role: string;
+    survived: boolean;
+    stats: PlayerStats;
+}
+
+interface GameReport {
+    game_id: string;
+    lobby_id: number;
+    started_at: number;
+    ended_at: number;
+    num_players: number;
+    num_rounds: number;
+    expansions: string[];
+    players: PlayerGameReport[];
+}
+
+function getBaseRole(role: string): string {
+    return role.replace(/_3p$/, '');
+}
+
+function getLocalizedRole(language: Language, role: string): string {
+    const key = 'icon-' + getBaseRole(role);
+    return getLabel(language, 'PlayerIcon', key);
+}
+
+function sortPlayers(players: PlayerGameReport[]): PlayerGameReport[] {
+    return [...players].sort((a, b) => {
+        if (a.survived !== b.survived) return a.survived ? -1 : 1;
+        return b.stats.kills - a.stats.kills;
+    });
+}
+
+function GameStatsTable({ game }: { game: GameReport }) {
+    const language = useLanguage();
+    const players = sortPlayers(game.players);
+
+    const yesNo = (value: boolean) => getLabel(language, 'ui', value ? 'BUTTON_YES' : 'BUTTON_NO');
+
+    const handleDownloadCsv = () => {
+        const header = [
+            getLabel(language, 'GameStats', 'COLUMN_PLAYER'),
+            getLabel(language, 'GameStats', 'COLUMN_CHARACTER'),
+            getLabel(language, 'GameStats', 'COLUMN_ROLE'),
+            getLabel(language, 'GameStats', 'COLUMN_SURVIVED'),
+            getLabel(language, 'GameStats', 'COLUMN_BANGS_PLAYED'),
+            getLabel(language, 'GameStats', 'COLUMN_ABILITY_USES'),
+            getLabel(language, 'GameStats', 'COLUMN_DYNAMITE_EXPLOSIONS'),
+            getLabel(language, 'GameStats', 'COLUMN_PRISON_TURNS'),
+            getLabel(language, 'GameStats', 'COLUMN_DUELS_LOST'),
+            getLabel(language, 'GameStats', 'COLUMN_KILLS'),
+        ];
+        const rows = players.map(player => [
+            player.username,
+            getLocalizedCardName(language, player.character),
+            getLocalizedRole(language, player.role),
+            yesNo(player.survived),
+            player.stats.bangs_played.toString(),
+            player.stats.ability_uses.toString(),
+            player.stats.dynamite_explosions.toString(),
+            player.stats.prison_turns_skipped.toString(),
+            player.stats.duels_lost.toString(),
+            player.stats.kills.toString(),
+        ]);
+        downloadCsv(`bang_game_${game.game_id}.csv`, [header, ...rows]);
+    };
+
+    return <div className="flex flex-col items-center gap-4 p-4">
+        <h1 className="text-2xl font-bold">{getLabel(language, 'GameStats', 'TITLE')}</h1>
+        <div className="text-gray-600">{getLabel(language, 'GameStats', 'NUM_ROUNDS')}: {game.num_rounds}</div>
+        <div className="overflow-x-auto w-full">
+            <table className="min-w-full border-collapse text-center">
+                <thead>
+                    <tr className="border-b border-gray-400">
+                        <th className="p-2">{getLabel(language, 'GameStats', 'COLUMN_PLAYER')}</th>
+                        <th className="p-2">{getLabel(language, 'GameStats', 'COLUMN_CHARACTER')}</th>
+                        <th className="p-2">{getLabel(language, 'GameStats', 'COLUMN_ROLE')}</th>
+                        <th className="p-2">{getLabel(language, 'GameStats', 'COLUMN_SURVIVED')}</th>
+                        <th className="p-2">{getLabel(language, 'GameStats', 'COLUMN_BANGS_PLAYED')}</th>
+                        <th className="p-2">{getLabel(language, 'GameStats', 'COLUMN_ABILITY_USES')}</th>
+                        <th className="p-2">{getLabel(language, 'GameStats', 'COLUMN_DYNAMITE_EXPLOSIONS')}</th>
+                        <th className="p-2">{getLabel(language, 'GameStats', 'COLUMN_PRISON_TURNS')}</th>
+                        <th className="p-2">{getLabel(language, 'GameStats', 'COLUMN_DUELS_LOST')}</th>
+                        <th className="p-2">{getLabel(language, 'GameStats', 'COLUMN_KILLS')}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {players.map(player => (
+                        <tr key={player.user_id} className="border-b border-gray-200">
+                            <td className="p-2 font-medium">{player.username}</td>
+                            <td className="p-2">{getLocalizedCardName(language, player.character)}</td>
+                            <td className="p-2">{getLocalizedRole(language, player.role)}</td>
+                            <td className="p-2">{yesNo(player.survived)}</td>
+                            <td className="p-2">{player.stats.bangs_played}</td>
+                            <td className="p-2">{player.stats.ability_uses}</td>
+                            <td className="p-2">{player.stats.dynamite_explosions}</td>
+                            <td className="p-2">{player.stats.prison_turns_skipped}</td>
+                            <td className="p-2">{player.stats.duels_lost}</td>
+                            <td className="p-2">{player.stats.kills}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+        <Button color='blue' onClick={handleDownloadCsv}>{getLabel(language, 'GameStats', 'BUTTON_DOWNLOAD_CSV')}</Button>
+    </div>;
+}
+
+function GameStatsInner() {
+    const language = useLanguage();
+    const params = new URLSearchParams(window.location.search);
+    const lobbyId = params.get('lobby') ?? '';
+
+    const gamesUrl = Env.bangGamesUrl + '?' + new URLSearchParams({ lobby: lobbyId, limit: '1' }).toString();
+    const games = useFetch<GameReport[]>(gamesUrl);
+
+    if (!games) {
+        return <div className="p-4 text-center">{getLabel(language, 'GameStats', 'LOADING')}</div>;
+    }
+    if (games.length === 0) {
+        return <div className="p-4 text-center">{getLabel(language, 'GameStats', 'NOT_FOUND')}</div>;
+    }
+    return <GameStatsTable game={games[0]} />;
+}
+
+export default function GameStatsScene() {
+    return <LanguageProvider>
+        <GameStatsInner />
+    </LanguageProvider>;
+}

--- a/src/Scenes/GameStats/Style/GameStats.css
+++ b/src/Scenes/GameStats/Style/GameStats.css
@@ -1,0 +1,53 @@
+.game-stats-scene {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 1.5em 1em;
+}
+
+.game-stats-panel {
+    width: fit-content;
+    max-width: 100%;
+    border: 2px solid #2d1000ff;
+    border-radius: 1em;
+    background-color: #ffffffd0;
+    padding: 1em 1.5em;
+    text-shadow: none;
+}
+
+.game-stats-title {
+    font-family: 'American Typewriter';
+    text-transform: uppercase;
+    text-align: center;
+    font-size: 20pt;
+    color: #2d1000ff;
+    margin: 0 0 0.2em;
+}
+
+.game-stats-subtitle {
+    text-align: center;
+    color: #5a3a26ff;
+    margin-bottom: 1em;
+}
+
+.game-stats-table th {
+    font-family: 'American Typewriter';
+    text-transform: uppercase;
+    font-size: 9pt;
+    color: #ffffff;
+    background-color: #2d1000ff;
+    white-space: nowrap;
+}
+
+.game-stats-table tbody tr:nth-child(even) {
+    background-color: #2d100014;
+}
+
+.game-stats-table tbody tr.game-stats-winner {
+    background-color: #ffce4d55;
+}
+
+.game-stats-table td, .game-stats-table th {
+    padding: 0.4em 0.6em;
+}

--- a/src/Utils/FileUtils.ts
+++ b/src/Utils/FileUtils.ts
@@ -1,3 +1,23 @@
+function csvEscape(value: string): string {
+    if (/[",\r\n]/.test(value)) {
+        return '"' + value.replace(/"/g, '""') + '"';
+    }
+    return value;
+}
+
+export function downloadCsv(filename: string, rows: string[][]): void {
+    const csvContent = rows.map(row => row.map(csvEscape).join(',')).join('\r\n');
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+}
+
 export async function loadFile(file: File): Promise<string> {
     return new Promise((resolve, reject) => {
         let reader = new FileReader();

--- a/src/game_stats.tsx
+++ b/src/game_stats.tsx
@@ -1,0 +1,11 @@
+import { StrictMode } from 'react';
+import ReactDOM from 'react-dom/client';
+import './index.css';
+import GameStatsScene from './Scenes/GameStats/GameStats';
+
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+root.render(
+  <StrictMode>
+    <GameStatsScene />
+  </StrictMode>
+);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,8 @@ export default defineConfig({
       input: {
         appGame: fileURLToPath(new URL('./index.html', import.meta.url)),
         appTracking: fileURLToPath(new URL('./tracking.html', import.meta.url)),
-        appAllCards: fileURLToPath(new URL('./all_cards.html', import.meta.url))
+        appAllCards: fileURLToPath(new URL('./all_cards.html', import.meta.url)),
+        appGameStats: fileURLToPath(new URL('./game_stats.html', import.meta.url))
       }
     }
   }


### PR DESCRIPTION
## Summary

Adds a "View Stats" button to the game-over screen (next to "Return to Lobby", visible to everyone) that opens a standalone stats/leaderboard page for the game that just finished, with CSV export. Requires the [companion `bang-server` PR](https://github.com/bangsalvoserver/bang-server/pull/13) (`GET /games`).

<img width="1400" height="800" alt="gamestats" src="https://github.com/user-attachments/assets/a6218df2-f0b1-4f1c-8727-3aeff7da13cd" />

## What's new

- `game_stats.html` / `src/Scenes/GameStats/GameStats.tsx` — a new satellite page (same pattern as the existing `/tracking` and `/all_cards` pages), looked up by `?lobby=<id>` against the server's `/games` API.
- Renders a leaderboard sorted by winner → survived → kills, with a highlighted row for the winner(s), localized character names and roles, and a "Download CSV" button.
- Styled to match the rest of the site rather than a generic table: the wood-gradient background, the same translucent parchment panel used by the lobby's game-options box, the "American Typewriter" font already used for card titles, and the saloon-door logo.
- New labels added in English and Czech (other locales fall back to the existing raw-key behavior until translated).

## Testing

Built with `tsc && vite build` (clean), then verified against a real running `bang-server` with headless Chromium: the leaderboard renders correct live data with zero console errors, and the CSV download produces a well-formed file. Confirmed visually via screenshot that the page matches the game's visual design.